### PR TITLE
Fixed onDrop never called

### DIFF
--- a/FileDrop.js
+++ b/FileDrop.js
@@ -94,8 +94,10 @@
         },
 
         _handleFrameDrop: function(event) {
-            this.resetDragging();
-            if (this.props.onFrameDrop) this.props.onFrameDrop(event);
+            if (!this.state.draggingOverTarget) {
+                this.resetDragging();
+                if (this.props.onFrameDrop) this.props.onFrameDrop(event);
+            }
         },
 
         render: function () {

--- a/FileDrop.js
+++ b/FileDrop.js
@@ -94,8 +94,8 @@
         },
 
         _handleFrameDrop: function(event) {
+            this.resetDragging();
             if (!this.state.draggingOverTarget) {
-                this.resetDragging();
                 if (this.props.onFrameDrop) this.props.onFrameDrop(event);
             }
         },


### PR DESCRIPTION
onDrop was never called because onFrameDrop was called even when dragging over the target. Fixed it by checking `this.state.draggingOverTarget` in `_handleFrameDrop`