### PR TITLE
Allow the user to cancel a drag event in the onFrameDragEnter callback

### DIFF
--- a/FileDrop.js
+++ b/FileDrop.js
@@ -86,8 +86,12 @@
             // "draggingOverFrame" (b/c you get one "dragenter" initially, and one "dragenter"/one "dragleave" for every bubble)
             this._dragCount += (event.type === "dragenter" ? 1 : -1);
             if (this._dragCount === 1) {
+                if (this.props.onFrameDragEnter) {
+					if (this.props.onFrameDragEnter(event) === false) {
+						return;
+					}
+				}
                 this.setState({draggingOverFrame: true});
-                if (this.props.onFrameDragEnter) this.props.onFrameDragEnter(event);
             } else if (this._dragCount === 0) {
                 if (this.props.onFrameDragLeave) this.props.onFrameDragLeave(event);
                 this.setState({draggingOverFrame: false});


### PR DESCRIPTION
This addresses issue #15 I just opened. The event only contains the `types` of the dragged element but this is enough to examine if the user drags a file, a url or text.

Tested like this:

```javascript
  handleDrop(files, event) {
    this.props.drop({files, dataTransfer: event.dataTransfer});
  }
  onFrameDragEnter(event) {
    return event.dataTransfer.types.indexOf('Files') >= 0;
  }
  render() {
    return (<FileDrop onDrop={this.handleDrop} onFrameDragEnter={this.onFrameDragEnter}>Drop here</FileDrop>);
  }
```