### PR TITLE
Repaired onDrop functionality

### DIFF
--- a/FileDrop.js
+++ b/FileDrop.js
@@ -103,6 +103,7 @@
                 this.resetDragging();
                 if (this.props.onFrameDrop) this.props.onFrameDrop(event);
             }
+            this._handleDrop(event);
         },
 
         render: function () {


### PR DESCRIPTION
onDrop was not recognizing the event and it was because resetDragging was preventing handleDrop from running so I simply called _handleDrop after if statements and everything works as expected:

```
        _handleFrameDrop: function(event) {
            if (!this.state.draggingOverTarget) {
                this.resetDragging();
                if (this.props.onFrameDrop) this.props.onFrameDrop(event);
            }
            this._handleDrop(event);
        },
```