### PR TITLE
Fix React console warnings

### DIFF
--- a/FileDrop.js
+++ b/FileDrop.js
@@ -1,27 +1,29 @@
 (function(root, factory) {
     if (typeof exports !== "undefined") {
         var React = require("react");
-        module.exports = factory(React);
+        var PropTypes = require("prop-types");
+        var createReactClass = require("create-react-class");
+        module.exports = factory(React, PropTypes, createReactClass);
     }
     else if (typeof define === "function" && define.amd) {
-        define(["react"], function(React) {
-            return factory(React);
+        define(["react", "prop-types", "create-react-class"], function(React, PropTypes, createReactClass) {
+            return factory(React, PropTypes, createReactClass);
         });
     }
     else {
-        factory(root.React);
+        factory(root.React, root.PropTypes, root.createReactClass);
     }
-}(this, function(React) {
+}(this, function(React, PropTypes, createReactClass) {
 
-    var FileDrop = React.createClass({
+    var FileDrop = createReactClass({
         displayName: "FileDrop",
 
         propTypes: {
-            onDrop: React.PropTypes.func,
-            onDragOver: React.PropTypes.func,
-            onDragLeave: React.PropTypes.func,
-            dropEffect: React.PropTypes.oneOf(["copy", "move", "link", "none"]),
-            targetAlwaysVisible: React.PropTypes.bool,
+            onDrop: PropTypes.func,
+            onDragOver: PropTypes.func,
+            onDragLeave: PropTypes.func,
+            dropEffect: PropTypes.oneOf(["copy", "move", "link", "none"]),
+            targetAlwaysVisible: PropTypes.bool,
             frame: function (props, propName, componentName) {
                 var prop = props[propName];
                 if (prop == null) {
@@ -31,9 +33,9 @@
                     return new Error("Warning: Prop `" + propName + "` must be one of the following: document, window, or an HTMLElement!");
                 }
             },
-            onFrameDragEnter: React.PropTypes.func,
-            onFrameDragLeave: React.PropTypes.func,
-            onFrameDrop: React.PropTypes.func
+            onFrameDragEnter: PropTypes.func,
+            onFrameDragLeave: PropTypes.func,
+            onFrameDrop: PropTypes.func
         },
 
         getDefaultProps: function () {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     },
     "homepage": "https://github.com/sarink/react-file-drop#readme",
     "dependencies": {
+        "create-react-class": "^15.5.2",
+        "prop-types": "^15.5.8"
     },
     "peerDependencies": {
         "react": ">=0.13"


### PR DESCRIPTION
Adds two NPM dependencies:
* prop-types
* create-react-class

Fixes the following console warnings that are currently thrown on page load in React 15.5:
* "Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead."
* "Warning: FileDrop: React.createClass is deprecated and will be removed in version 16. Use plain JavaScript classes instead. If you're not yet ready to migrate, create-react-class is available on npm as a drop-in replacement."

Addresses https://github.com/sarink/react-file-drop/issues/18.
