### PR TITLE
fix IE 11  in drag over handler

### DIFF
--- a/FileDrop.js
+++ b/FileDrop.js
@@ -64,16 +64,20 @@
             }
         },
 
+        _isIE: (navigator.userAgent.indexOf('MSIE')!==-1 || navigator.appVersion.indexOf('Trident/') > 0),
+
         _handleDragOver: function (event) {
             event.preventDefault();
             event.stopPropagation();
-            event.dataTransfer.dropEffect = this.props.dropEffect;
+            if (!this._isIE) {
+                event.dataTransfer.dropEffect = this.props.dropEffect;
 
-            // set active drag state only when file is dragged into
-            // (in mozilla when file is dragged effect is "uninitialized")
-            var effectAllowed = event.dataTransfer.effectAllowed;
-            if (effectAllowed === "all" || effectAllowed === "uninitialized") {
-                this.setState({draggingOverTarget: true});
+                // set active drag state only when file is dragged into
+                // (in mozilla when file is dragged effect is "uninitialized")
+                var effectAllowed = event.dataTransfer.effectAllowed;
+                if (effectAllowed === "all" || effectAllowed === "uninitialized") {
+                    this.setState({draggingOverTarget: true});
+                }
             }
 
             if (this.props.onDragOver) this.props.onDragOver(event);


### PR DESCRIPTION
Exclude accessing dataTransfer.dropEffect and dataTransfer.effectAllowed in handle drag over for IE 11, which cause a lot of annoying errors in console. It should fix #12