### PR TITLE
Window existence check updated

### DIFF
--- a/dist/FileDrop/FileDrop.js
+++ b/dist/FileDrop/FileDrop.js
@@ -121,7 +121,7 @@ var FileDrop = /** @class */ (function (_super) {
     };
     FileDrop.defaultProps = {
         dropEffect: 'copy',
-        frame: window ? window.document : undefined,
+        frame: typeof window === 'undefined' ? undefined : window.document,
         className: 'file-drop',
         targetClassName: 'file-drop-target',
         draggingOverFrameClassName: 'file-drop-dragging-over-frame',

--- a/src/FileDrop/FileDrop.tsx
+++ b/src/FileDrop/FileDrop.tsx
@@ -25,7 +25,7 @@ export interface IFileDropState {
 class FileDrop extends React.PureComponent<IFileDropProps, IFileDropState> {
   static defaultProps = {
     dropEffect: ('copy' as TDropEffects),
-    frame: window ? window.document : undefined,
+    frame: typeof window === 'undefined' ? undefined : window.document,
     className: 'file-drop',
     targetClassName: 'file-drop-target',
     draggingOverFrameClassName: 'file-drop-dragging-over-frame',


### PR DESCRIPTION
Without this update, using command line building (like `gatbsy build`) throws an error.