### PR TITLE
Introduce onTargetClick handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Next, define an `onDrop` prop, whenever a user drops their files onto the `targe
 
 Lastly, you'll need to style it.
 
+You can also define an `onTargetClick` prop if you want to let user browse their files from disk. Below you can find instruction how to do that.
+
 ## Styling
 
 By default, the component comes with no styles. You can grab the [demo CSS](https://raw.githubusercontent.com/sarink/react-file-drop/master/src/Demo/Demo.css) to get started.
@@ -69,6 +71,8 @@ For custom class names (if you're using something like JSS) you can use the foll
 
 `onDragLeave: function(event)`: Callback when the user leaves the target. Removes the `file-drop-dragging-over-target` class from the `file-drop-target`.
 
+`onTargetClick: function(event)`: Callback when the user clicks _anywhere_ on the target.
+
 `dropEffect - string "copy" || "move" || "link" || "none" (default: "copy")`: Learn more about [HTML5 dropEffects](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer#dropEffect.28.29). Not available in IE :(
 
 `frame: document || HTMLElement (default: document)`: This is the scope or "frame" that the user must drag some file(s) over to kick things off.
@@ -86,6 +90,53 @@ For custom class names (if you're using something like JSS) you can use the foll
 `draggingOverFrameClassName: string (default: "file-drop-dragging-over-frame")`: Class given to the target div when file is being dragged over frame.
 
 `draggingOverTargetClassName: string (default: "file-drop-dragging-over-target")`: Class given to the target div when file is being dragged over target.
+
+## Uploading files using click handler
+
+In order to let user upload files with click on the `file-drop-target`, you will need to specify an `input[type="file"]` somewhere in your code. You will also need a ref, that will be passed to the input, to call a `click` method on it.
+
+Steps:
+
+1. Define ref for input:
+
+```javascript
+const fileInputRef = useRef(null);
+```
+
+2. Define input change handler:
+
+```javascript
+const onFileInputChange = (event) => {
+  const { files } = event.target;
+  // do something with your files...
+}
+```
+
+3. Add input to your code:
+
+```html
+<input
+  onChange={onFileInputChange}
+  ref={fileInputRef}
+  type="file"
+  className="hidden"
+/>
+```
+
+4. Define target click handler:
+
+```javascript
+const onTargetClick = () => {
+  fileInputRef.current.click()
+}
+```
+
+5. Add target click handler to `FileDrop` component:
+
+```html
+<FileDrop
+  onTargetClick={onTargetClick}
+```
 
 ## Contributing
 

--- a/file-drop/src/FileDrop.tsx
+++ b/file-drop/src/FileDrop.tsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, {
   DragEvent as ReactDragEvent,
   DragEventHandler as ReactDragEventHandler,
+  ReactEventHandler,
 } from 'react';
 
 export type DropEffects = 'copy' | 'move' | 'link' | 'none';
@@ -18,6 +19,7 @@ export interface FileDropProps {
   onDragOver?: ReactDragEventHandler<HTMLDivElement>;
   onDragLeave?: ReactDragEventHandler<HTMLDivElement>;
   onDrop?: (files: FileList | null, event: ReactDragEvent<HTMLDivElement>) => any;
+  onTargetClick?: ReactEventHandler<HTMLDivElement>;
   dropEffect?: DropEffects;
 }
 
@@ -55,6 +57,7 @@ export class FileDrop extends React.PureComponent<FileDropProps, FileDropState> 
     onDragOver: PropTypes.func,
     onDragLeave: PropTypes.func,
     onDrop: PropTypes.func,
+    onTargetClick: PropTypes.func,
     dropEffect: PropTypes.oneOf(['copy', 'move', 'link', 'none']),
     frame: (props: FileDropProps, propName: keyof FileDropProps, componentName: string) => {
       const prop = props[propName];
@@ -174,6 +177,13 @@ export class FileDrop extends React.PureComponent<FileDropProps, FileDropState> 
     this.resetDragging();
   };
 
+  handleTargetClick: ReactEventHandler<HTMLDivElement> = (event) => {
+    if (this.props.onTargetClick) {
+      this.props.onTargetClick(event);
+    }
+    this.resetDragging();
+  };
+
   stopFrameListeners = (frame: FileDropProps['frame']) => {
     if (frame) {
       removeEventListener('dragenter', this.handleFrameDrag);
@@ -211,7 +221,9 @@ export class FileDrop extends React.PureComponent<FileDropProps, FileDropState> 
         onDragLeave={this.handleDragLeave}
         onDrop={this.handleDrop}
       >
-        <div className={fileDropTargetClassName}>{children}</div>
+        <div className={fileDropTargetClassName} onClick={this.handleTargetClick}>
+          {children}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
This change introduces optional click handler to `file-drop-target` HTMLDivElement. Allows to upload files not only using drag&drop feature, but also by browsing files from disk. Instruction how to use it added to Readme.