### PR TITLE
Revert typo introduced in d4ee6d088be58fa6804f1dbdc56cf2940746c747

### DIFF
--- a/file-drop/src/FileDrop.tsx
+++ b/file-drop/src/FileDrop.tsx
@@ -176,7 +176,7 @@ export class FileDrop extends React.PureComponent<FileDropProps, FileDropState> 
 
   stopFrameListeners = (frame: FileDropProps['frame']) => {
     if (frame) {
-      removeEventListener('dragenter', this.handleFrameDrag);
+      frame.removeEventListener('dragenter', this.handleFrameDrag);
       frame.removeEventListener('dragleave', this.handleFrameDrag);
       frame.removeEventListener('drop', this.handleFrameDrop);
     }


### PR DESCRIPTION
Seems like this is leaking the event listener.. looks accidental