### PR TITLE
Add react and react-dom ^17.0.0 as peer dependency

### DIFF
--- a/file-drop/package.json
+++ b/file-drop/package.json
@@ -48,8 +48,8 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.13.1 || ^17.0.0",
+    "react-dom": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@types/prop-types": "^15.7.3",


### PR DESCRIPTION
Hey :) We like to use this awesome lib with react 17 as peer dependency. Unfortunately there is an error on installation right now.