### PR TITLE
React 18: the children prop now needs to be listed explicitly

### DIFF
--- a/file-drop/src/FileDrop.tsx
+++ b/file-drop/src/FileDrop.tsx
@@ -8,6 +8,7 @@ import React, {
 export type DropEffects = 'copy' | 'move' | 'link' | 'none';
 
 export interface FileDropProps {
+  children: React.ReactNode;
   className?: string;
   targetClassName?: string;
   draggingOverFrameClassName?: string;


### PR DESCRIPTION
As of React 18, the `children` prop now needs to be listed explicitly when defining props.  See the [React 18 Upgrade Guide](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions) and https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210