### PR TITLE
Fix "Failed to parse source map" error by turning off creation of sourceMap

### DIFF
--- a/file-drop/tsconfig.json
+++ b/file-drop/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "node",
     "outDir": "dist",
     "resolveJsonModule": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true,
     "target": "es5"
     // "traceResolution": true


### PR DESCRIPTION
Small change to address immediate problem with warnings in create-react-app.