### PR TITLE
Resolve prop validate warning for frame prop in SSR apps by matching prop-types with ts types

### DIFF
--- a/file-drop/src/FileDrop.tsx
+++ b/file-drop/src/FileDrop.tsx
@@ -60,19 +60,7 @@ export class FileDrop extends React.PureComponent<FileDropProps, FileDropState> 
     onDrop: PropTypes.func,
     onTargetClick: PropTypes.func,
     dropEffect: PropTypes.oneOf(['copy', 'move', 'link', 'none']),
-    frame: (props: FileDropProps, propName: keyof FileDropProps, componentName: string) => {
-      const prop = props[propName];
-      if (prop == null) {
-        return new Error(
-          'Warning: Required prop `' + propName + '` was not specified in `' + componentName + '`'
-        );
-      }
-      if (prop !== document && !(prop instanceof HTMLElement)) {
-        return new Error(
-          'Warning: Prop `' + propName + '` must be one of the following: document, HTMLElement!'
-        );
-      }
-    },
+    frame: typeof window === 'undefined' ? undefined : PropTypes.instanceOf(Element),
     onFrameDragEnter: PropTypes.func,
     onFrameDragLeave: PropTypes.func,
     onFrameDrop: PropTypes.func,


### PR DESCRIPTION
For SSR apps I would see a console warning about the frame prop being null, but according to TS types `frame` can undefined and for SSR it's expected to be undefined. Therefore this PR just updates the prop-type validation to be optional and checks prop is an instance of an element.

The error I was seeing:
```shell
Warning: Failed prop type: Warning: Required prop `frame` was not specified in `FileDrop`
    at FileDrop (/node_modules/.pnpm/react-file-drop@3.1.6/node_modules/react-file-drop/FileDrop.js:24:24)
    at SideUploadButton (./UploadButton.tsx:16:46)
    at div
    at div
    at Side (./Side.tsx:35:17)
    at div
```
